### PR TITLE
Remove go-kit dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
 go:
-  - 1.6.2
+  - 1.6.3
   - tip
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2016 WP Technolgies Inc
+Copyright © 2016 WP Technologies Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -1,29 +1,24 @@
 package middleware
 
 import (
+	"expvar"
 	"time"
 
 	"github.com/Wattpad/sqsconsumer"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/Wattpad/sqsconsumer/middleware/movingaverage"
 	"golang.org/x/net/context"
 )
 
 // TrackMetrics decorates a MessageHandler to collect metrics about successes, failures and runtime reports in ms*10.
-func TrackMetrics(successVarName, failureVarName, timingVarName string) MessageHandlerDecorator {
-	successes := expvar.NewCounter(successVarName)
-	failures := expvar.NewCounter(failureVarName)
-
-	// histogram from 0-100000ms with 3 sigfigs tracking 50, 95 and 99 %iles
-	h := expvar.NewHistogram(timingVarName, 0, 100000, 3, 50, 95, 99)
-
-	timing := metrics.NewTimeHistogram(time.Millisecond, h)
+func TrackMetrics(successes, failures *expvar.Int, timing *expvar.Float) MessageHandlerDecorator {
+	ema := movingaverage.New(5 * time.Second)
 
 	return func(fn sqsconsumer.MessageHandlerFunc) sqsconsumer.MessageHandlerFunc {
 		return func(ctx context.Context, msg string) error {
 			start := time.Now()
 			defer func() {
-				timing.Observe(time.Since(start))
+				v := ema.Update(time.Since(start).Seconds() * 1000)
+				timing.Set(v)
 			}()
 
 			err := fn(ctx, msg)

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -12,9 +12,12 @@ import (
 
 func TestTrackMetricsMiddleware(t *testing.T) {
 	// given a TrackMetrics with known expvar metric names
-	m := TrackMetrics("success", "fail", "timing")
+	successes := expvar.NewInt("success")
+	fails := expvar.NewInt("fail")
+	timing := expvar.NewFloat("timing")
+	m := TrackMetrics(successes, fails, timing)
 
-	// when tracking 9 successes, 6 failures, with runtimes in ms of 0, 1, 5, 10, 11 (3 of each)
+	// when tracking 9 successes, 6 failures with varied runtimes
 	for i := 0; i < 3; i++ {
 		m(testHandlerReturnAfterDelay(true, 10*time.Millisecond))(context.Background(), "")
 		m(testHandlerReturnAfterDelay(true, 20*time.Millisecond))(context.Background(), "")
@@ -24,12 +27,10 @@ func TestTrackMetricsMiddleware(t *testing.T) {
 	}
 
 	// expvar metrics for success and fail counts should match
-	assert.Equal(t, "9", expvar.Get("success").String(), "Success count should match")
-	assert.Equal(t, "6", expvar.Get("fail").String(), "Failure count should match")
+	assert.Equal(t, "9", successes.String(), "Success count should match")
+	assert.Equal(t, "6", fails.String(), "Failure count should match")
 
-	// expvar metric for timing quantiles 50, 99 should be 5, 11ms
-	q50, _ := strconv.Atoi(expvar.Get("timing_p50").String())
-	q99, _ := strconv.Atoi(expvar.Get("timing_p99").String())
-	assert.InDelta(t, 50, q50, 5, "Time Q50 should match (within 10%)")
-	assert.InDelta(t, 110, q99, 11, "Time Q99 should match (within 10%)")
+	// expvar metric for timing moving average
+	avg, _ := strconv.ParseFloat(timing.String(), 64)
+	assert.InDelta(t, 15, avg, 1.5, "Timing average should match (within 10%)")
 }


### PR DESCRIPTION
It was only used in the TrackMetrics middleware which we don't use anywhere
and which was anemic enough that users should really always implement their
own infrastructure-appropriate version anyway.