### PR TITLE
Added support for Message.MessageAttributes in receiveMessages

### DIFF
--- a/queue_consumer.go
+++ b/queue_consumer.go
@@ -84,11 +84,12 @@ func (mf *Consumer) startBatchExtender(ctx context.Context, wg *sync.WaitGroup, 
 
 func (mf *Consumer) receiveMessages(ctx context.Context, wg *sync.WaitGroup, ch chan<- job, dq chan<- *sqs.Message) {
 	rcvParams := &sqs.ReceiveMessageInput{
-		QueueUrl:            mf.s.URL,
-		MaxNumberOfMessages: aws.Int64(awsBatchSizeLimit),
-		WaitTimeSeconds:     aws.Int64(mf.WaitSeconds),
-		VisibilityTimeout:   aws.Int64(mf.ReceiveVisibilityTimoutSeconds),
-		AttributeNames:      []*string{aws.String("SentTimestamp"), aws.String("ApproximateReceiveCount")},
+		QueueUrl:               mf.s.URL,
+		MaxNumberOfMessages:    aws.Int64(awsBatchSizeLimit),
+		WaitTimeSeconds:        aws.Int64(mf.WaitSeconds),
+		VisibilityTimeout:      aws.Int64(mf.ReceiveVisibilityTimoutSeconds),
+		AttributeNames:         []*string{aws.String("SentTimestamp"), aws.String("ApproximateReceiveCount")},
+		MessageAttributeNames:  []*string{aws.String("All")},
 	}
 
 	for {


### PR DESCRIPTION
Current ReceiveMessageInput invocation in the consumer does not account for SQS message attributes. This change adds a request for all attributes when receiving messages.