### PR TITLE
Support graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,23 @@ Example:
 
   c := sqsconsumer.NewConsumer(service, handler)
 
-	wg := &sync.WaitGroup{}
-	for i := 0; i < numFetchers; i++ {
+  wg := &sync.WaitGroup{}
+  for i := 0; i < numFetchers; i++ {
     wg.Add(1)
-		go func() {
+    go func() {
       // Consumer will stop when shutDown is closed
       err := c.Run(ctx, sqsconsumer.WithShutdownChan(shutDown))
       // Handle error
-			wg.Done()
-		}()
-	}
+      wg.Done()
+    }()
+  }
 
   <-shutDown
   // Force shutdown after deadline
-	time.AfterFunc(30*time.Second, cancel)
+  time.AfterFunc(30*time.Second, cancel)
 
-	// Wait for all the consumers to exit cleanly
-	wg.Wait()
+  // Wait for all the consumers to exit cleanly
+  wg.Wait()
 ```
 
 # TODO

--- a/example/main.go
+++ b/example/main.go
@@ -60,28 +60,24 @@ func main() {
 	// start the consumers
 	log.Println("Starting queue consumers")
 
+	// create the consumer and bind it to a queue and processor function
+	c := sqsconsumer.NewConsumer(s, handler)
+	c.SetLogger(log.Printf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	wg := &sync.WaitGroup{}
 	wg.Add(numFetchers)
 	for i := 0; i < numFetchers; i++ {
 		go func() {
-			// create the consumer and bind it to a queue and processor function
-			c := sqsconsumer.NewConsumer(s, handler)
-			c.SetLogger(log.Printf)
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			go func() {
-				<-shutDown
-				time.AfterFunc(30*time.Second, cancel)
-				c.ShutDown()
-			}()
-
-			c.Run(ctx)
-
+			c.Run(ctx, sqsconsumer.WithShutdownChan(shutDown))
 			wg.Done()
 		}()
 	}
+
+	<-shutDown
+	time.AfterFunc(30*time.Second, cancel)
 
 	// wait for all the consumers to exit cleanly
 	wg.Wait()

--- a/example/main.go
+++ b/example/main.go
@@ -37,14 +37,14 @@ func main() {
 		log.Fatalf("Could not set up queue '%s': %s", queueName, err)
 	}
 
-	// set up a context which will gracefully cancel the worker on interrupt
-	fetchCtx, cancelFetch := context.WithCancel(context.Background())
+	shutDown := make(chan struct{})
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, os.Kill)
+
 	go func() {
 		<-term
 		log.Println("Starting graceful shutdown")
-		cancelFetch()
+		close(shutDown)
 	}()
 
 	// set up metrics - note TrackMetrics does not run the http server, and uses expvar
@@ -68,8 +68,16 @@ func main() {
 			c := sqsconsumer.NewConsumer(s, handler)
 			c.SetLogger(log.Printf)
 
-			// start running the consumer with a context that will be cancelled when a graceful shutdown is requested
-			c.Run(fetchCtx)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go func() {
+				<-shutDown
+				time.AfterFunc(30*time.Second, cancel)
+				c.ShutDown()
+			}()
+
+			c.Run(ctx)
 
 			wg.Done()
 		}()

--- a/options.go
+++ b/options.go
@@ -1,0 +1,21 @@
+package sqsconsumer
+
+type runOpts struct {
+	shutDown <-chan struct{}
+}
+
+type RunOption func(o *runOpts)
+
+// WithShutdownChan accepts a channel that will gracefully shut down
+// the consumer when it is closed.  The consumer will stop receiving messages from SQS
+// and will return from the Run method once in-flight handlers have completed.
+//
+// The channel must be closed for shutdown to occur.  Sending a value down the channel
+// will not shut down the consumer.
+//
+// The Run method's context.Context may be canceled during this time to abort pending
+// operations early. This is done co-operatively and requires the consumer's handler func
+// to honour the context cancelation.
+func WithShutdownChan(shutDown <-chan struct{}) RunOption {
+	return func(o *runOpts) { o.shutDown = shutDown }
+}

--- a/queue_consumer.go
+++ b/queue_consumer.go
@@ -102,10 +102,8 @@ func (mf *Consumer) receiveMessages(ctx context.Context, wg *sync.WaitGroup, don
 		select {
 		case <-ctx.Done():
 			return
-		case _, open := <-done:
-			if !open {
-				return
-			}
+		case <-done:
+			return
 		default:
 		}
 
@@ -142,10 +140,8 @@ func (mf *Consumer) receiveMessages(ctx context.Context, wg *sync.WaitGroup, don
 func (mf *Consumer) Run(ctx context.Context, opts ...RunOption) error {
 	ro := resolveRunOptions(opts)
 	select {
-	case _, open := <-ro.shutDown:
-		if !open {
-			return ErrShutdownChannelClosed
-		}
+	case <-ro.shutDown:
+		return ErrShutdownChannelClosed
 	default:
 	}
 

--- a/queue_consumer_test.go
+++ b/queue_consumer_test.go
@@ -294,6 +294,22 @@ func TestQueueConsumerRunHonorsContextOnShutdown(t *testing.T) {
 	assert.Equal(t, context.Canceled, err)
 }
 
+func TestQueueConsumerRunReturnsErrorAfterShutdown(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	handler := func(context.Context, string) error { return nil }
+
+	m := mock.NewMockSQSAPI(ctl)
+	q := NewConsumer(&SQSService{Svc: m, Logger: NoopLogger}, handler)
+
+	shutDown := make(chan struct{})
+	close(shutDown)
+
+	err := q.Run(context.Background(), WithShutdownChan(shutDown))
+	assert.Equal(t, ErrShutdownChannelClosed, err)
+}
+
 func noop(ctx context.Context, msg string) error {
 	return nil
 }

--- a/queue_consumer_test.go
+++ b/queue_consumer_test.go
@@ -1,6 +1,8 @@
 package sqsconsumer
 
 import (
+	"sort"
+	"sync"
 	"testing"
 
 	"time"
@@ -205,6 +207,117 @@ func TestQueueConsumerRunRetriesOnErrors(t *testing.T) {
 	assert.InDelta(t, ngo, runtime.NumGoroutine(), 2, "Should not leak goroutines")
 }
 
+func TestQueueConsumerRunDrainsOnShutdown(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	received := &sqs.ReceiveMessageOutput{
+		Messages: []*sqs.Message{
+			&sqs.Message{MessageId: aws.String("i1"), ReceiptHandle: aws.String("r1"), Body: aws.String("b01")},
+			&sqs.Message{MessageId: aws.String("i2"), ReceiptHandle: aws.String("r2"), Body: aws.String("b02")},
+			&sqs.Message{MessageId: aws.String("i3"), ReceiptHandle: aws.String("r3"), Body: aws.String("b03")},
+			&sqs.Message{MessageId: aws.String("i4"), ReceiptHandle: aws.String("r4"), Body: aws.String("b04")},
+			&sqs.Message{MessageId: aws.String("i5"), ReceiptHandle: aws.String("r5"), Body: aws.String("b05")},
+		},
+	}
+
+	m := mock.NewMockSQSAPI(ctl)
+	h := &handler{}
+	q := NewConsumer(&SQSService{Svc: m, Logger: NoopLogger}, h.HandleMessage)
+
+	m.EXPECT().
+		ReceiveMessage(gomock.Any()).
+		Do(func(*sqs.ReceiveMessageInput) {
+			q.ShutDown()
+		}).
+		Return(received, nil).
+		AnyTimes()
+	m.EXPECT().DeleteMessageBatch(gomock.Any()).AnyTimes().Return(&sqs.DeleteMessageBatchOutput{}, nil)
+	m.EXPECT().ChangeMessageVisibilityBatch(gomock.Any()).AnyTimes()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Run(ctx)
+	assert.NoError(t, err)
+
+	expected := []string{"b01", "b02", "b03", "b04", "b05"}
+	sort.Strings(h.messages)
+	assert.Equal(t, expected, h.messages)
+}
+
+func TestQueueConsumerRunHonorsContextOnShutdown(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	handler := func(ctx context.Context, _ string) error {
+		assert.Error(t, ctx.Err())
+		return nil
+	}
+
+	m := mock.NewMockSQSAPI(ctl)
+	q := NewConsumer(&SQSService{Svc: m, Logger: NoopLogger}, handler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m.EXPECT().
+		ReceiveMessage(gomock.Any()).
+		Do(func(*sqs.ReceiveMessageInput) {
+			q.ShutDown()
+			cancel()
+		}).
+		Return(
+			&sqs.ReceiveMessageOutput{
+				Messages: []*sqs.Message{
+					&sqs.Message{MessageId: aws.String("i1"), ReceiptHandle: aws.String("r1"), Body: aws.String("b01")},
+					&sqs.Message{MessageId: aws.String("i2"), ReceiptHandle: aws.String("r2"), Body: aws.String("b02")},
+					&sqs.Message{MessageId: aws.String("i3"), ReceiptHandle: aws.String("r3"), Body: aws.String("b03")},
+				},
+			},
+			nil).
+		AnyTimes()
+	m.EXPECT().DeleteMessageBatch(gomock.Any()).Return(&sqs.DeleteMessageBatchOutput{}, nil).AnyTimes()
+	m.EXPECT().ChangeMessageVisibilityBatch(gomock.Any()).AnyTimes()
+
+	err := q.Run(ctx)
+	assert.Equal(t, context.Canceled, err)
+}
+
+func TestQueueConsumerRunReturnsErrorAfterShutdown(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	handler := func(ctx context.Context, _ string) error {
+		return nil
+	}
+
+	m := mock.NewMockSQSAPI(ctl)
+	q := NewConsumer(&SQSService{Svc: m, Logger: NoopLogger}, handler)
+
+	q.ShutDown()
+
+	err := q.Run(context.Background())
+	assert.Equal(t, ErrConsumerAlreadyShutDown, err)
+}
+
 func noop(ctx context.Context, msg string) error {
+	return nil
+}
+
+type handler struct {
+	lock     sync.Mutex
+	messages []string
+}
+
+func (h *handler) HandleMessage(ctx context.Context, msg string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	h.messages = append(h.messages, msg)
 	return nil
 }


### PR DESCRIPTION
This enables caller to signal the consumer to stop consuming messages
while allowing in-flight handlers to run to completion.

This change does not change the existing API's behaviour, except that
new errors may be returned from `Run` if `ShutDown` is called.

BEND-323