### PR TITLE
Replace deprecated session.New -> session.NewSession

### DIFF
--- a/sqs_interface_test.go
+++ b/sqs_interface_test.go
@@ -10,5 +10,7 @@ import (
 )
 
 func TestSQSInterfaceImplementsSQSAPI(t *testing.T) {
-	assert.Implements(t, (*sqsconsumer.SQSAPI)(nil), sqs.New(session.New()))
+	sess, err := session.NewSession()
+	assert.NoError(t, err)
+	assert.Implements(t, (*sqsconsumer.SQSAPI)(nil), sqs.New(sess))
 }

--- a/sqs_service.go
+++ b/sqs_service.go
@@ -32,8 +32,12 @@ func SQSServiceForQueue(queueName string, opts ...AWSConfigOption) (*SQSService,
 		o(conf)
 	}
 
-	svc := sqs.New(session.New(conf))
-	return NewSQSService(queueName, svc)
+	sess, err := session.NewSession(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSQSService(queueName, sqs.New(sess))
 }
 
 type AWSConfigOption func(*aws.Config)


### PR DESCRIPTION
NewSession correctly handles credentials provided by EKS IRSA, whereas
the deprecated New does not.