### PR TITLE
Make job workers count and messages batch size configurable

### DIFF
--- a/cleanup_delete.go
+++ b/cleanup_delete.go
@@ -78,8 +78,8 @@ func (dq *deleteQueue) deleteFromPending() {
 	defer dq.Unlock()
 
 	n := len(dq.entries)
-	if n > awsBatchSizeLimit {
-		n = awsBatchSizeLimit
+	if n > defaultMessagesBatchSizeLimit {
+		n = defaultMessagesBatchSizeLimit
 	}
 	fails, err := dq.deleteBatch(dq.entries[:n])
 	if err != nil {
@@ -105,7 +105,7 @@ func (dq *deleteQueue) start(ctx context.Context, wg *sync.WaitGroup) {
 			dq.Lock()
 			n := len(dq.entries)
 			dq.Unlock()
-			if n >= awsBatchSizeLimit {
+			if n >= defaultMessagesBatchSizeLimit {
 				dq.deleteFromPending()
 			}
 		case <-time.After(dq.accumulationTimeout):

--- a/queue_consumer.go
+++ b/queue_consumer.go
@@ -223,7 +223,7 @@ type Consumer struct {
 	Logger  func(string, ...interface{})
 
 	JobWorkersCount                  int
-	MessagesBatchSizeLimit           int64
+	MessagesBatchSizeLimit           int64 // The maximum number of messages to return is 10.
 	WaitSeconds                      int64
 	ReceiveVisibilityTimoutSeconds   int64
 	ExtendVisibilityTimeoutBySeconds int64


### PR DESCRIPTION
The consumer will ask for `awsBatchSizeLimit=10` messages per each SQS.ReceiveMessage call (10 is the max). It will also launch 10 concurrent goroutines to process these messages by calling the Consumer.handler function.

- In some services, we want to regulate the number of concurrent goroutines to avoid overwhelming downstream services or DBs.
- We also want to control max number of messages we want to return in one batch.
- This line of code is a bit confusing because it is not actually the number of messages per batch, it is the number of goroutines (workers) processing the messages. Both can be (and probably will be) different. 
https://github.com/Wattpad/sqsconsumer/pull/21/files#diff-82ca95f80ac2454bd62d950f0491975af74cae32f432b4b74d70594f02387161R42
- All defaults remained the same, with no breaking changes. 